### PR TITLE
Updates metadata to declare support for RedHat 8 and CentOS 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,13 +23,13 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7", "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7", "8"
       ]
     },
     {


### PR DESCRIPTION
Version 8 of RedHat and CentOS is added to the list of supported
OSses in metadata.json.  Version 7 support is retained.

Fixes #1